### PR TITLE
Fix warnings and code quality issues

### DIFF
--- a/src/main/java/chatbot/Command.java
+++ b/src/main/java/chatbot/Command.java
@@ -23,7 +23,6 @@ public enum Command {
 
     private final String rep;
     private String args = "";
-    private final boolean isBreaking;
 
     /**
      * Constructor that initialises a user command.
@@ -32,7 +31,6 @@ public enum Command {
      */
     Command(String cmd) {
         this.rep = cmd.toLowerCase();
-        this.isBreaking = this.rep.equals("bye");
     }
 
     /**

--- a/src/main/java/chatbot/Response.java
+++ b/src/main/java/chatbot/Response.java
@@ -56,7 +56,7 @@ public class Response {
     }
 
     /**
-     * Display a notification after user adds a task.
+     * Displays a notification after user adds a task.
      *
      * @param tl The task list.
      * @param t  The added task.

--- a/src/main/java/chatbot/Task.java
+++ b/src/main/java/chatbot/Task.java
@@ -12,7 +12,7 @@ public class Task implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final String description;
-    private boolean done;
+    private boolean isDone;
 
     /**
      * Constructor for the task.
@@ -21,12 +21,12 @@ public class Task implements Serializable {
      */
     public Task(String desc) {
         this.description = desc;
-        this.done = false;
+        this.isDone = false;
     }
 
     @Override
     public String toString() {
-        return (done ? "[X] " : "[ ] ") + description;
+        return (isDone ? "[X] " : "[ ] ") + description;
     }
 
     public boolean contains(String s) {
@@ -39,10 +39,10 @@ public class Task implements Serializable {
      * @throws AlreadyMarkedException If the task is already marked as done.
      */
     public void mark() throws AlreadyMarkedException {
-        if (this.done) {
+        if (this.isDone) {
             throw new AlreadyMarkedException();
         }
-        this.done = true;
+        this.isDone = true;
     }
 
     /**
@@ -51,9 +51,9 @@ public class Task implements Serializable {
      * @throws AlreadyUnmarkedException If the task is not marked as done.
      */
     public void unmark() throws AlreadyUnmarkedException {
-        if (!this.done) {
+        if (!this.isDone) {
             throw new AlreadyUnmarkedException();
         }
-        this.done = false;
+        this.isDone = false;
     }
 }


### PR DESCRIPTION
There were some fields that were either unused or had unclear naming.

Renaming these fields and removing them where possible can improve code quality.